### PR TITLE
Fix bare-domain 404: register / -> login redirect in app factory

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -255,6 +255,11 @@ def create_app(config_name: str = 'default') -> Flask:
         }
     )
 
+    @app.route('/')
+    def index():
+        from flask import redirect, url_for
+        return redirect(url_for('auth.login'))
+
     # Register blueprints
     from app.routes.admin import admin_bp
     from app.routes.api import api_bp

--- a/run.py
+++ b/run.py
@@ -8,8 +8,6 @@ quietly serving traffic from an unsafe development server.
 import logging
 import os
 
-from flask import Response, redirect, url_for
-
 from app import create_app, socketio
 
 # Configure logging to reduce noise
@@ -20,11 +18,6 @@ logging.getLogger('engineio').setLevel(logging.WARNING)  # Reduce EngineIO logs
 
 _config_name = os.getenv('FLASK_CONFIG') or 'default'
 app = create_app(_config_name)
-
-
-@app.route('/')
-def home() -> Response:
-    return redirect(url_for('auth.login'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `/` -> login redirect lived only in run.py (dev server), so gunicorn
`wsgi:app` never registered it and `automod.agpt.co/` 404'd in prod (and
dev). Moves the route into `create_app()` so both entrypoints redirect the
bare domain to `/auth/login`. Verified locally: `GET /` now 302s to login.